### PR TITLE
Refactor/repository

### DIFF
--- a/cmd/initdata/main.go
+++ b/cmd/initdata/main.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"time"
 
 	"github.com/holocycle/holo-back/internal/app/config"
+	app_context "github.com/holocycle/holo-back/pkg/context2"
 	"github.com/holocycle/holo-back/pkg/db"
 	"github.com/holocycle/holo-back/pkg/model"
 	"github.com/holocycle/holo-back/pkg/repository"
@@ -20,13 +22,16 @@ func main() {
 	db, err := db.NewDB(&config.DB)
 	defer db.Close()
 
+	ctx := context.Background()
+	ctx = app_context.SetDB(ctx, db)
+
 	user1 := model.NewUser("user1", "test1@test.com", "https://yt3.ggpht.com/a/AATXAJwHPp_TkvcWJyblt9XVYDjNSjrj6KdpQSCQNQ=s288-c-k-c0xffffffff-no-rj-mo")
 	user2 := model.NewUser("user2", "test2@test.com", "https://yt3.ggpht.com/a/AATXAJwHPp_TkvcWJyblt9XVYDjNSjrj6KdpQSCQNQ=s288-c-k-c0xffffffff-no-rj-mo")
 	user3 := model.NewUser("user3", "test3@test.com", "https://yt3.ggpht.com/a/AATXAJwHPp_TkvcWJyblt9XVYDjNSjrj6KdpQSCQNQ=s288-c-k-c0xffffffff-no-rj-mo")
 	userRepository := repository.NewUserRepository()
-	_ = userRepository.NewQuery(db).Create(user1)
-	_ = userRepository.NewQuery(db).Create(user2)
-	_ = userRepository.NewQuery(db).Create(user3)
+	_ = userRepository.NewQuery(ctx).Create(user1)
+	_ = userRepository.NewQuery(ctx).Create(user2)
+	_ = userRepository.NewQuery(ctx).Create(user3)
 
 	v1PublishAt := time.Date(2020, 4, 23, 17, 01, 42, 0, time.UTC).Local()
 	v2PublishAt := time.Date(2020, 3, 27, 11, 0, 12, 0, time.UTC).Local()
@@ -35,19 +40,19 @@ func main() {
 	video2 := model.NewVideo("X9zw0QF12Kc", "UC-hM6YJuNYVAmUWxeIr9FeA", "サクラカゼ / さくらみこ【オリジナル曲】", "さくらみこ 2ndオリジナル楽曲", 231, "https://i.ytimg.com/vi/X9zw0QF12Kc/default.jpg", "https://i.ytimg.com/vi/X9zw0QF12Kc/mqdefault.jpg", "https://i.ytimg.com/vi/X9zw0QF12Kc/hqdefault.jpg", &v2PublishAt)
 	video3 := model.NewVideo("lwbGo-O6buc", "UC1opHUrw8rvnsadT-iGp7Cg", "【コラボ耐久】あくシオ💓わちゃわちゃ二人組がゼロからエンドラ倒すまで終われない！？【湊あくあ/紫咲シオン】", "隣人戦争、遂に宇宙へ―…。", 23961, "https://i.ytimg.com/vi/lwbGo-O6buc/default.jpg", "https://i.ytimg.com/vi/lwbGo-O6buc/mqdefault.jpg", "https://i.ytimg.com/vi/lwbGo-O6buc/hqdefault.jpg", &v3PublishAt)
 	videoRepository := repository.NewVideoRepository()
-	_ = videoRepository.NewQuery(db).Create(video1)
-	_ = videoRepository.NewQuery(db).Create(video2)
-	_ = videoRepository.NewQuery(db).Create(video3)
+	_ = videoRepository.NewQuery(ctx).Create(video1)
+	_ = videoRepository.NewQuery(ctx).Create(video2)
+	_ = videoRepository.NewQuery(ctx).Create(video3)
 
 	clip1 := model.NewClip(user1.ID, "タイトル", "動画の説明", "xccH7xxG5zc", 2799, 2871, model.ClipStatusPublic)
 	clip2 := model.NewClip(user1.ID, "サクラカゼ", "動画の説明", "X9zw0QF12Kc", 0, 100, model.ClipStatusPublic)
 	clip3 := model.NewClip(user2.ID, "切り抜き動画を見る紫咲シオン", "動画の説明", "lwbGo-O6buc", 1320, 1420, model.ClipStatusPublic)
 	clip4 := model.NewClip(user3.ID, "切り抜き動画を見る紫咲シオン", "動画の説明", "lwbGo-O6buc", 1320, 1420, model.ClipStatusPublic)
 	clipRepository := repository.NewClipRepository()
-	_ = clipRepository.NewQuery(db).Create(clip1)
-	_ = clipRepository.NewQuery(db).Create(clip2)
-	_ = clipRepository.NewQuery(db).Create(clip3)
-	_ = clipRepository.NewQuery(db).Create(clip4)
+	_ = clipRepository.NewQuery(ctx).Create(clip1)
+	_ = clipRepository.NewQuery(ctx).Create(clip2)
+	_ = clipRepository.NewQuery(ctx).Create(clip3)
+	_ = clipRepository.NewQuery(ctx).Create(clip4)
 
 	tags := []model.Tag{
 		*model.NewTag("ときのそら", "#4374FF"),
@@ -80,7 +85,7 @@ func main() {
 	}
 	tagRepository := repository.NewTagRepository()
 	for i := 0; i < len(tags); i++ {
-		_ = tagRepository.NewQuery(db).Create(&tags[i])
+		_ = tagRepository.NewQuery(ctx).Create(&tags[i])
 	}
 
 	clipTagged1 := model.NewClipTagged(clip1.ID, tags[0].ID, clip1.UserID)
@@ -88,30 +93,30 @@ func main() {
 	clipTagged3 := model.NewClipTagged(clip2.ID, tags[2].ID, clip2.UserID)
 	clipTagged4 := model.NewClipTagged(clip3.ID, tags[3].ID, clip3.UserID)
 	clipTaggedRepository := repository.NewClipTaggedRepository()
-	_ = clipTaggedRepository.NewQuery(db).Create(clipTagged1)
-	_ = clipTaggedRepository.NewQuery(db).Create(clipTagged2)
-	_ = clipTaggedRepository.NewQuery(db).Create(clipTagged3)
-	_ = clipTaggedRepository.NewQuery(db).Create(clipTagged4)
+	_ = clipTaggedRepository.NewQuery(ctx).Create(clipTagged1)
+	_ = clipTaggedRepository.NewQuery(ctx).Create(clipTagged2)
+	_ = clipTaggedRepository.NewQuery(ctx).Create(clipTagged3)
+	_ = clipTaggedRepository.NewQuery(ctx).Create(clipTagged4)
 
 	favorite1 := model.NewFavorite(clip1.ID, user1.ID)
 	favorite2 := model.NewFavorite(clip2.ID, user1.ID)
 	favorite3 := model.NewFavorite(clip3.ID, user1.ID)
 	favorite4 := model.NewFavorite(clip1.ID, user2.ID)
 	favoriteRepository := repository.NewFavoriteRepository()
-	_ = favoriteRepository.NewQuery(db).Create(favorite1)
-	_ = favoriteRepository.NewQuery(db).Create(favorite2)
-	_ = favoriteRepository.NewQuery(db).Create(favorite3)
-	_ = favoriteRepository.NewQuery(db).Create(favorite4)
+	_ = favoriteRepository.NewQuery(ctx).Create(favorite1)
+	_ = favoriteRepository.NewQuery(ctx).Create(favorite2)
+	_ = favoriteRepository.NewQuery(ctx).Create(favorite3)
+	_ = favoriteRepository.NewQuery(ctx).Create(favorite4)
 
 	comments1 := model.NewComment(user1.ID, clip1.ID, "1get")
 	comments2 := model.NewComment(user2.ID, clip1.ID, "2get")
 	comments3 := model.NewComment(user3.ID, clip1.ID, "3get")
 	comments4 := model.NewComment(user1.ID, clip2.ID, "てえてえ")
 	commentsRepository := repository.NewCommentRepository()
-	_ = commentsRepository.NewQuery(db).Create(comments1)
-	_ = commentsRepository.NewQuery(db).Create(comments2)
-	_ = commentsRepository.NewQuery(db).Create(comments3)
-	_ = commentsRepository.NewQuery(db).Create(comments4)
+	_ = commentsRepository.NewQuery(ctx).Create(comments1)
+	_ = commentsRepository.NewQuery(ctx).Create(comments2)
+	_ = commentsRepository.NewQuery(ctx).Create(comments3)
+	_ = commentsRepository.NewQuery(ctx).Create(comments4)
 
 	clipList := []model.Cliplist{
 		*model.NewCliplist(user1.ID, "クリップリスト1", "詳細", model.CliplistStatusPublic),
@@ -122,7 +127,7 @@ func main() {
 	}
 	clipListRepository := repository.NewCliplistRepository()
 	for i := 0; i < len(clipList); i++ {
-		_ = clipListRepository.NewQuery(db).Create(&clipList[i])
+		_ = clipListRepository.NewQuery(ctx).Create(&clipList[i])
 	}
 
 	clipListContains := []model.CliplistContain{
@@ -140,7 +145,7 @@ func main() {
 	}
 	clipListContainRepository := repository.NewCliplistContainRepository()
 	for i := 0; i < len(clipList); i++ {
-		_ = clipListContainRepository.NewQuery(db).Create(&clipListContains[i])
+		_ = clipListContainRepository.NewQuery(ctx).Create(&clipListContains[i])
 	}
 
 	bookmarks1 := model.NewBookMark(clipList[0].ID, user1.ID)
@@ -148,8 +153,8 @@ func main() {
 	bookmarks3 := model.NewBookMark(clipList[0].ID, user3.ID)
 	bookmarks4 := model.NewBookMark(clipList[1].ID, user1.ID)
 	bookmarkRepository := repository.NewBookmarkRepository()
-	_ = bookmarkRepository.NewQuery(db).Create(bookmarks1)
-	_ = bookmarkRepository.NewQuery(db).Create(bookmarks2)
-	_ = bookmarkRepository.NewQuery(db).Create(bookmarks3)
-	_ = bookmarkRepository.NewQuery(db).Create(bookmarks4)
+	_ = bookmarkRepository.NewQuery(ctx).Create(bookmarks1)
+	_ = bookmarkRepository.NewQuery(ctx).Create(bookmarks2)
+	_ = bookmarkRepository.NewQuery(ctx).Create(bookmarks3)
+	_ = bookmarkRepository.NewQuery(ctx).Create(bookmarks4)
 }

--- a/internal/app/controller/app_controller.go
+++ b/internal/app/controller/app_controller.go
@@ -6,18 +6,21 @@ import (
 	"github.com/holocycle/holo-back/internal/app/config"
 	"github.com/holocycle/holo-back/pkg/context"
 	"github.com/holocycle/holo-back/pkg/model"
+	"github.com/holocycle/holo-back/pkg/repository"
 	"github.com/pkg/errors"
 
 	"github.com/labstack/echo/v4"
 )
 
 type AppController struct {
-	Config *config.AppConfig
+	Config              *config.AppConfig
+	RepositoryContainer *repository.Container
 }
 
 func NewAppController(config *config.AppConfig) *AppController {
 	return &AppController{
-		Config: config,
+		Config:              config,
+		RepositoryContainer: repository.NewContainer(),
 	}
 }
 

--- a/internal/app/controller/authn_controller.go
+++ b/internal/app/controller/authn_controller.go
@@ -9,6 +9,7 @@ import (
 	"github.com/holocycle/holo-back/internal/app/config"
 	app_context "github.com/holocycle/holo-back/internal/app/context"
 	"github.com/holocycle/holo-back/pkg/context"
+	app_context2 "github.com/holocycle/holo-back/pkg/context2"
 	"github.com/holocycle/holo-back/pkg/httpclient"
 	"github.com/holocycle/holo-back/pkg/model"
 	"github.com/holocycle/holo-back/pkg/repository"
@@ -61,6 +62,7 @@ func (c *AuthnController) LoginGoogle(ctx context.Context) error {
 
 func (c *AuthnController) LoginGoogleCallback(ctx context.Context) error {
 	log := ctx.GetLog()
+	goCtx := app_context2.FromEchoContext(ctx)
 
 	code := ctx.FormValue("code")
 	if code == "" {
@@ -108,8 +110,7 @@ func (c *AuthnController) LoginGoogleCallback(ctx context.Context) error {
 	}
 	log.Info("success to retrieve email info", zap.String("email", email))
 
-	tx := ctx.GetDB()
-	user, err := c.UserRepository.NewQuery(tx).
+	user, err := c.UserRepository.NewQuery(goCtx).
 		Where(&model.User{Email: email}).Find()
 	if err != nil && !repository.NotFoundError(err) {
 		return err
@@ -119,7 +120,7 @@ func (c *AuthnController) LoginGoogleCallback(ctx context.Context) error {
 		log.Info("user not found", zap.String("email", email))
 		//TODO: imageURLの取得処理
 		user = model.NewUser(email, email, "https://yt3.ggpht.com/a/AATXAJwHPp_TkvcWJyblt9XVYDjNSjrj6KdpQSCQNQ=s288-c-k-c0xffffffff-no-rj-mo")
-		if err := c.UserRepository.NewQuery(tx).Create(user); err != nil {
+		if err := c.UserRepository.NewQuery(goCtx).Create(user); err != nil {
 			return err
 		}
 		log.Info("success to create user", zap.Any("user", user))
@@ -133,7 +134,7 @@ func (c *AuthnController) LoginGoogleCallback(ctx context.Context) error {
 	expireAt := time.Now().Add(tokenDuration)
 	session := model.NewSession(user.ID, &expireAt)
 
-	if err := c.SessionRepository.NewQuery(tx).Create(session); err != nil {
+	if err := c.SessionRepository.NewQuery(goCtx).Create(session); err != nil {
 		return err
 	}
 	log.Info("success to craete session", zap.Any("session", session))
@@ -143,10 +144,10 @@ func (c *AuthnController) LoginGoogleCallback(ctx context.Context) error {
 }
 
 func (c *AuthnController) Logout(ctx context.Context) error {
+	goCtx := app_context2.FromEchoContext(ctx)
 	session := app_context.GetSession(ctx)
 
-	tx := ctx.GetDB()
-	_, err := c.SessionRepository.NewQuery(tx).
+	_, err := c.SessionRepository.NewQuery(goCtx).
 		Where(&model.Session{ID: session.ID}).Delete()
 	if err != nil {
 		return err

--- a/internal/app/controller/cliplist_controller.go
+++ b/internal/app/controller/cliplist_controller.go
@@ -8,17 +8,13 @@ import (
 	"github.com/holocycle/holo-back/pkg/api"
 	"github.com/holocycle/holo-back/pkg/context"
 	app_context2 "github.com/holocycle/holo-back/pkg/context2"
-	"github.com/holocycle/holo-back/pkg/repository"
 	"github.com/holocycle/holo-back/pkg/service"
 	"github.com/labstack/echo/v4"
 )
 
 type CliplistController struct {
-	Config                    *config.AppConfig
-	ClipRepository            repository.ClipRepository
-	CliplistRepository        repository.CliplistRepository
-	CliplistContainRepository repository.CliplistContainRepository
-	ServiceContainer          *service.Container
+	Config           *config.AppConfig
+	ServiceContainer *service.Container
 }
 
 func NewCliplistController(config *config.AppConfig) *CliplistController {

--- a/internal/app/controller/comment_controller.go
+++ b/internal/app/controller/comment_controller.go
@@ -16,14 +16,14 @@ import (
 )
 
 type CommentController struct {
-	Config            *config.AppConfig
-	CommentRepository repository.CommentRepository
+	Config              *config.AppConfig
+	RepositoryContainer *repository.Container
 }
 
 func NewCommentController(config *config.AppConfig) *CommentController {
 	return &CommentController{
-		Config:            config,
-		CommentRepository: repository.NewCommentRepository(),
+		Config:              config,
+		RepositoryContainer: repository.NewContainer(),
 	}
 }
 
@@ -52,7 +52,7 @@ func (c *CommentController) ListComments(ctx context.Context) error {
 
 	// TODO: clipIDが実在することのバリデーション処理
 
-	query := c.CommentRepository.NewQuery(goCtx)
+	query := c.RepositoryContainer.CommentRepository.NewQuery(goCtx)
 	if req.Limit > 0 {
 		query = query.Limit(req.Limit)
 	}
@@ -94,7 +94,7 @@ func (c *CommentController) GetComment(ctx context.Context) error {
 
 	// TODO: clipIDが実在することのバリデーション処理
 
-	comment, err := c.CommentRepository.NewQuery(goCtx).
+	comment, err := c.RepositoryContainer.CommentRepository.NewQuery(goCtx).
 		Where(
 			&model.Comment{
 				ID:     commentID,
@@ -136,7 +136,7 @@ func (c *CommentController) PostComment(ctx context.Context) error {
 		clipID,
 		req.Content,
 	)
-	if err := c.CommentRepository.NewQuery(goCtx).Create(comment); err != nil {
+	if err := c.RepositoryContainer.CommentRepository.NewQuery(goCtx).Create(comment); err != nil {
 		log.Error("failed to create comment", zap.Any("comment", comment))
 		return err
 	}
@@ -173,7 +173,7 @@ func (c *CommentController) DeleteComment(ctx context.Context) error {
 		UserID: app_context.GetSession(ctx).UserID,
 		ClipID: clipID,
 	}
-	rows, err := c.CommentRepository.NewQuery(goCtx).Where(cond).Delete()
+	rows, err := c.RepositoryContainer.CommentRepository.NewQuery(goCtx).Where(cond).Delete()
 	if err != nil {
 		return err
 	}

--- a/internal/app/controller/comment_controller.go
+++ b/internal/app/controller/comment_controller.go
@@ -7,6 +7,7 @@ import (
 	app_context "github.com/holocycle/holo-back/internal/app/context"
 	"github.com/holocycle/holo-back/pkg/api"
 	"github.com/holocycle/holo-back/pkg/context"
+	app_context2 "github.com/holocycle/holo-back/pkg/context2"
 	"github.com/holocycle/holo-back/pkg/converter"
 	"github.com/holocycle/holo-back/pkg/model"
 	"github.com/holocycle/holo-back/pkg/repository"
@@ -35,6 +36,7 @@ func (c *CommentController) Register(e *echo.Echo) {
 
 func (c *CommentController) ListComments(ctx context.Context) error {
 	log := ctx.GetLog()
+	goCtx := app_context2.FromEchoContext(ctx)
 
 	clipID := ctx.Param("clip_id")
 	if clipID == "" {
@@ -50,8 +52,7 @@ func (c *CommentController) ListComments(ctx context.Context) error {
 
 	// TODO: clipIDが実在することのバリデーション処理
 
-	tx := ctx.GetDB()
-	query := c.CommentRepository.NewQuery(tx)
+	query := c.CommentRepository.NewQuery(goCtx)
 	if req.Limit > 0 {
 		query = query.Limit(req.Limit)
 	}
@@ -73,6 +74,7 @@ func (c *CommentController) ListComments(ctx context.Context) error {
 
 func (c *CommentController) GetComment(ctx context.Context) error {
 	log := ctx.GetLog()
+	goCtx := app_context2.FromEchoContext(ctx)
 
 	clipID := ctx.Param("clip_id")
 	if clipID == "" {
@@ -92,8 +94,7 @@ func (c *CommentController) GetComment(ctx context.Context) error {
 
 	// TODO: clipIDが実在することのバリデーション処理
 
-	tx := ctx.GetDB()
-	comment, err := c.CommentRepository.NewQuery(tx).
+	comment, err := c.CommentRepository.NewQuery(goCtx).
 		Where(
 			&model.Comment{
 				ID:     commentID,
@@ -115,6 +116,7 @@ func (c *CommentController) GetComment(ctx context.Context) error {
 
 func (c *CommentController) PostComment(ctx context.Context) error {
 	log := ctx.GetLog()
+	goCtx := app_context2.FromEchoContext(ctx)
 
 	req := &api.PostCommentRequest{}
 	if err := inject(ctx, req); err != nil {
@@ -129,13 +131,12 @@ func (c *CommentController) PostComment(ctx context.Context) error {
 
 	// TODO: clipIDが実在することのバリデーション処理
 
-	tx := ctx.GetDB()
 	comment := model.NewComment(
 		app_context.GetSession(ctx).UserID,
 		clipID,
 		req.Content,
 	)
-	if err := c.CommentRepository.NewQuery(tx).Create(comment); err != nil {
+	if err := c.CommentRepository.NewQuery(goCtx).Create(comment); err != nil {
 		log.Error("failed to create comment", zap.Any("comment", comment))
 		return err
 	}
@@ -148,6 +149,7 @@ func (c *CommentController) PostComment(ctx context.Context) error {
 
 func (c *CommentController) DeleteComment(ctx context.Context) error {
 	log := ctx.GetLog()
+	goCtx := app_context2.FromEchoContext(ctx)
 
 	req := &api.DeleteCommentRequest{}
 	if err := inject(ctx, req); err != nil {
@@ -166,13 +168,12 @@ func (c *CommentController) DeleteComment(ctx context.Context) error {
 
 	// TODO: clipIDが実在することのバリデーション処理
 
-	tx := ctx.GetDB()
 	cond := &model.Comment{
 		ID:     commentID,
 		UserID: app_context.GetSession(ctx).UserID,
 		ClipID: clipID,
 	}
-	rows, err := c.CommentRepository.NewQuery(tx).Where(cond).Delete()
+	rows, err := c.CommentRepository.NewQuery(goCtx).Where(cond).Delete()
 	if err != nil {
 		return err
 	}

--- a/internal/app/controller/favorite_controller.go
+++ b/internal/app/controller/favorite_controller.go
@@ -7,6 +7,7 @@ import (
 	app_context "github.com/holocycle/holo-back/internal/app/context"
 	"github.com/holocycle/holo-back/pkg/api"
 	"github.com/holocycle/holo-back/pkg/context"
+	app_context2 "github.com/holocycle/holo-back/pkg/context2"
 	"github.com/holocycle/holo-back/pkg/model"
 	"github.com/holocycle/holo-back/pkg/repository"
 	"github.com/labstack/echo/v4"
@@ -32,12 +33,14 @@ func (c *FavoriteController) Register(e *echo.Echo) {
 }
 
 func (c *FavoriteController) PutFavorite(ctx context.Context) error {
+	goCtx := app_context2.FromEchoContext(ctx)
+
 	clipID := ctx.Param("clip_id")
 	if clipID == "" {
 		return echo.NewHTTPError(http.StatusBadRequest, "please specify clip_id")
 	}
 
-	if _, err := c.ClipRepository.NewQuery(ctx.GetDB()).
+	if _, err := c.ClipRepository.NewQuery(goCtx).
 		Where(&model.Clip{ID: clipID, Status: model.ClipStatusPublic}).
 		Find(); err != nil {
 		if repository.NotFoundError(err) {
@@ -47,7 +50,7 @@ func (c *FavoriteController) PutFavorite(ctx context.Context) error {
 	}
 
 	favorite := model.NewFavorite(clipID, app_context.GetUserID(ctx))
-	_, err := c.FavoriteRepository.NewQuery(ctx.GetDB()).Where(favorite).Find()
+	_, err := c.FavoriteRepository.NewQuery(goCtx).Where(favorite).Find()
 	if err != nil && !repository.NotFoundError(err) {
 		return err
 	}
@@ -55,7 +58,7 @@ func (c *FavoriteController) PutFavorite(ctx context.Context) error {
 		return ctx.JSON(http.StatusConflict, &api.PutFavoriteResponse{})
 	}
 
-	if err := c.FavoriteRepository.NewQuery(ctx.GetDB()).Create(favorite); err != nil {
+	if err := c.FavoriteRepository.NewQuery(goCtx).Create(favorite); err != nil {
 		return err
 	}
 
@@ -63,12 +66,14 @@ func (c *FavoriteController) PutFavorite(ctx context.Context) error {
 }
 
 func (c *FavoriteController) DeleteFavorite(ctx context.Context) error {
+	goCtx := app_context2.FromEchoContext(ctx)
+
 	clipID := ctx.Param("clip_id")
 	if clipID == "" {
 		return echo.NewHTTPError(http.StatusBadRequest, "please specify clip_id")
 	}
 
-	if _, err := c.ClipRepository.NewQuery(ctx.GetDB()).
+	if _, err := c.ClipRepository.NewQuery(goCtx).
 		Where(&model.Clip{ID: clipID, Status: model.ClipStatusPublic}).
 		Find(); err != nil {
 		if repository.NotFoundError(err) {
@@ -78,7 +83,7 @@ func (c *FavoriteController) DeleteFavorite(ctx context.Context) error {
 	}
 
 	favorite := model.NewFavorite(clipID, app_context.GetUserID(ctx))
-	rows, err := c.FavoriteRepository.NewQuery(ctx.GetDB()).Where(favorite).Delete()
+	rows, err := c.FavoriteRepository.NewQuery(goCtx).Where(favorite).Delete()
 	if err != nil {
 		return err
 	}

--- a/internal/app/controller/liver_controller.go
+++ b/internal/app/controller/liver_controller.go
@@ -7,6 +7,7 @@ import (
 	"github.com/holocycle/holo-back/internal/app/config"
 	"github.com/holocycle/holo-back/pkg/api"
 	"github.com/holocycle/holo-back/pkg/context"
+	app_context2 "github.com/holocycle/holo-back/pkg/context2"
 	"github.com/holocycle/holo-back/pkg/converter"
 	"github.com/holocycle/holo-back/pkg/model"
 	"github.com/holocycle/holo-back/pkg/repository"
@@ -34,8 +35,8 @@ func (c *LiverController) Register(e *echo.Echo) {
 }
 
 func (c *LiverController) ListLivers(ctx context.Context) error {
-	tx := ctx.GetDB()
-	livers, err := c.LiverRepository.NewQuery(tx).JoinChannel().FindAll()
+	goCtx := app_context2.FromEchoContext(ctx)
+	livers, err := c.LiverRepository.NewQuery(goCtx).JoinChannel().FindAll()
 	if err != nil {
 		return err
 	}
@@ -57,12 +58,12 @@ func (c *LiverController) ListLivers(ctx context.Context) error {
 		}
 
 		for _, channel := range channels {
-			if err := c.ChannelRepository.NewQuery(ctx.GetDB()).Save(channel); err != nil {
+			if err := c.ChannelRepository.NewQuery(goCtx).Save(channel); err != nil {
 				return err
 			}
 		}
 
-		livers, err = c.LiverRepository.NewQuery(tx).JoinChannel().FindAll()
+		livers, err = c.LiverRepository.NewQuery(goCtx).JoinChannel().FindAll()
 		if err != nil {
 			return err
 		}
@@ -74,13 +75,13 @@ func (c *LiverController) ListLivers(ctx context.Context) error {
 }
 
 func (c *LiverController) GetLiver(ctx context.Context) error {
+	goCtx := app_context2.FromEchoContext(ctx)
 	liverID := ctx.Param("liver_id")
 	if liverID == "" {
 		return echo.NewHTTPError(http.StatusBadRequest, "please specify liver_id")
 	}
 
-	tx := ctx.GetDB()
-	liver, err := c.LiverRepository.NewQuery(tx).
+	liver, err := c.LiverRepository.NewQuery(goCtx).
 		JoinChannel().Where(&model.Liver{ID: liverID}).Find()
 	if err != nil {
 		return echo.NewHTTPError(http.StatusNotFound, "liver was not found")

--- a/internal/app/controller/liver_controller.go
+++ b/internal/app/controller/liver_controller.go
@@ -16,16 +16,14 @@ import (
 )
 
 type LiverController struct {
-	Config            *config.AppConfig
-	LiverRepository   repository.LiverRepository
-	ChannelRepository repository.ChannelRepository
+	Config              *config.AppConfig
+	RepositoryContainer *repository.Container
 }
 
 func NewLiverController(config *config.AppConfig) *LiverController {
 	return &LiverController{
-		Config:            config,
-		LiverRepository:   repository.NewLiverRepository(),
-		ChannelRepository: repository.NewChannelRepository(),
+		Config:              config,
+		RepositoryContainer: repository.NewContainer(),
 	}
 }
 
@@ -36,7 +34,7 @@ func (c *LiverController) Register(e *echo.Echo) {
 
 func (c *LiverController) ListLivers(ctx context.Context) error {
 	goCtx := app_context2.FromEchoContext(ctx)
-	livers, err := c.LiverRepository.NewQuery(goCtx).JoinChannel().FindAll()
+	livers, err := c.RepositoryContainer.LiverRepository.NewQuery(goCtx).JoinChannel().FindAll()
 	if err != nil {
 		return err
 	}
@@ -58,12 +56,12 @@ func (c *LiverController) ListLivers(ctx context.Context) error {
 		}
 
 		for _, channel := range channels {
-			if err := c.ChannelRepository.NewQuery(goCtx).Save(channel); err != nil {
+			if err := c.RepositoryContainer.ChannelRepository.NewQuery(goCtx).Save(channel); err != nil {
 				return err
 			}
 		}
 
-		livers, err = c.LiverRepository.NewQuery(goCtx).JoinChannel().FindAll()
+		livers, err = c.RepositoryContainer.LiverRepository.NewQuery(goCtx).JoinChannel().FindAll()
 		if err != nil {
 			return err
 		}
@@ -81,7 +79,7 @@ func (c *LiverController) GetLiver(ctx context.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "please specify liver_id")
 	}
 
-	liver, err := c.LiverRepository.NewQuery(goCtx).
+	liver, err := c.RepositoryContainer.LiverRepository.NewQuery(goCtx).
 		JoinChannel().Where(&model.Liver{ID: liverID}).Find()
 	if err != nil {
 		return echo.NewHTTPError(http.StatusNotFound, "liver was not found")

--- a/internal/app/controller/user_controller.go
+++ b/internal/app/controller/user_controller.go
@@ -7,6 +7,7 @@ import (
 	app_context "github.com/holocycle/holo-back/internal/app/context"
 	"github.com/holocycle/holo-back/pkg/api"
 	"github.com/holocycle/holo-back/pkg/context"
+	app_context2 "github.com/holocycle/holo-back/pkg/context2"
 	"github.com/holocycle/holo-back/pkg/converter"
 	"github.com/holocycle/holo-back/pkg/model"
 	"github.com/holocycle/holo-back/pkg/repository"
@@ -38,6 +39,7 @@ func (c *UserController) Register(e *echo.Echo) {
 
 func (c *UserController) ListUsers(ctx context.Context) error {
 	log := ctx.GetLog()
+	goCtx := app_context2.FromEchoContext(ctx)
 
 	req := &api.ListUserRequest{}
 	if err := inject(ctx, req); err != nil {
@@ -45,8 +47,7 @@ func (c *UserController) ListUsers(ctx context.Context) error {
 	}
 	log.Info("success to validate", zap.Any("req", req))
 
-	tx := ctx.GetDB()
-	query := c.UserRepository.NewQuery(tx)
+	query := c.UserRepository.NewQuery(goCtx)
 	if req.Limit > 0 {
 		query = query.Limit(req.Limit)
 	}
@@ -71,6 +72,7 @@ func (c *UserController) ListUsers(ctx context.Context) error {
 
 func (c *UserController) GetUsersMe(ctx context.Context) error {
 	log := ctx.GetLog()
+	goCtx := app_context2.FromEchoContext(ctx)
 
 	req := &api.GetLoginUserRequest{}
 	if err := inject(ctx, req); err != nil {
@@ -78,9 +80,8 @@ func (c *UserController) GetUsersMe(ctx context.Context) error {
 	}
 	log.Info("success to validate", zap.Any("req", req))
 
-	tx := ctx.GetDB()
 	loginUserID := app_context.GetSession(ctx).UserID
-	loginUser, err := c.UserRepository.NewQuery(tx).Where(&model.User{ID: loginUserID}).Find()
+	loginUser, err := c.UserRepository.NewQuery(goCtx).Where(&model.User{ID: loginUserID}).Find()
 	if err != nil {
 		return err
 	}
@@ -95,6 +96,7 @@ func (c *UserController) GetUsersMe(ctx context.Context) error {
 func (c *UserController) GetLoginUserFavorites(ctx context.Context) error {
 	loginUserID := app_context.GetSession(ctx).UserID
 	log := ctx.GetLog()
+	goCtx := app_context2.FromEchoContext(ctx)
 
 	req := &api.GetUserFavoritesRequest{}
 	if err := inject(ctx, req); err != nil {
@@ -102,8 +104,7 @@ func (c *UserController) GetLoginUserFavorites(ctx context.Context) error {
 	}
 	log.Info("success to validate", zap.Any("req", req))
 
-	tx := ctx.GetDB()
-	favorites, err := c.FavoriteRepository.NewQuery(tx).
+	favorites, err := c.FavoriteRepository.NewQuery(goCtx).
 		Where(&model.Favorite{UserID: loginUserID}).
 		JoinClip().
 		FindAll()
@@ -118,14 +119,15 @@ func (c *UserController) GetLoginUserFavorites(ctx context.Context) error {
 
 func (c *UserController) GetOneUser(ctx context.Context) error {
 	log := ctx.GetLog()
+	goCtx := app_context2.FromEchoContext(ctx)
+
 	userID := ctx.Param("user_id")
 	if userID == "" {
 		return echo.NewHTTPError(http.StatusBadRequest, "please specify user_id")
 	}
 	log.Debug("success to validate request", zap.String("userID", userID))
 
-	tx := ctx.GetDB()
-	user, err := c.UserRepository.NewQuery(tx).Where(&model.User{ID: userID}).Find()
+	user, err := c.UserRepository.NewQuery(goCtx).Where(&model.User{ID: userID}).Find()
 	if err != nil {
 		return err
 	}
@@ -139,14 +141,15 @@ func (c *UserController) GetOneUser(ctx context.Context) error {
 
 func (c *UserController) GetOneUsersFavorites(ctx context.Context) error {
 	log := ctx.GetLog()
+	goCtx := app_context2.FromEchoContext(ctx)
+
 	userID := ctx.Param("user_id")
 	if userID == "" {
 		return echo.NewHTTPError(http.StatusBadRequest, "please specify user_id")
 	}
 	log.Debug("success to validate request", zap.String("userID", userID))
 
-	tx := ctx.GetDB()
-	favorites, err := c.FavoriteRepository.NewQuery(tx).
+	favorites, err := c.FavoriteRepository.NewQuery(goCtx).
 		Where(&model.Favorite{UserID: userID}).
 		JoinClip().
 		FindAll()

--- a/internal/app/controller/user_controller.go
+++ b/internal/app/controller/user_controller.go
@@ -16,16 +16,14 @@ import (
 )
 
 type UserController struct {
-	Config             *config.AppConfig
-	UserRepository     repository.UserRepository
-	FavoriteRepository repository.FavoriteRepository
+	Config              *config.AppConfig
+	RepositoryContainer *repository.Container
 }
 
 func NewUserController(config *config.AppConfig) *UserController {
 	return &UserController{
-		Config:             config,
-		UserRepository:     repository.NewUserRepository(),
-		FavoriteRepository: repository.NewFavoriteRepository(),
+		Config:              config,
+		RepositoryContainer: repository.NewContainer(),
 	}
 }
 
@@ -47,7 +45,7 @@ func (c *UserController) ListUsers(ctx context.Context) error {
 	}
 	log.Info("success to validate", zap.Any("req", req))
 
-	query := c.UserRepository.NewQuery(goCtx)
+	query := c.RepositoryContainer.UserRepository.NewQuery(goCtx)
 	if req.Limit > 0 {
 		query = query.Limit(req.Limit)
 	}
@@ -81,7 +79,7 @@ func (c *UserController) GetUsersMe(ctx context.Context) error {
 	log.Info("success to validate", zap.Any("req", req))
 
 	loginUserID := app_context.GetSession(ctx).UserID
-	loginUser, err := c.UserRepository.NewQuery(goCtx).Where(&model.User{ID: loginUserID}).Find()
+	loginUser, err := c.RepositoryContainer.UserRepository.NewQuery(goCtx).Where(&model.User{ID: loginUserID}).Find()
 	if err != nil {
 		return err
 	}
@@ -104,7 +102,7 @@ func (c *UserController) GetLoginUserFavorites(ctx context.Context) error {
 	}
 	log.Info("success to validate", zap.Any("req", req))
 
-	favorites, err := c.FavoriteRepository.NewQuery(goCtx).
+	favorites, err := c.RepositoryContainer.FavoriteRepository.NewQuery(goCtx).
 		Where(&model.Favorite{UserID: loginUserID}).
 		JoinClip().
 		FindAll()
@@ -127,7 +125,7 @@ func (c *UserController) GetOneUser(ctx context.Context) error {
 	}
 	log.Debug("success to validate request", zap.String("userID", userID))
 
-	user, err := c.UserRepository.NewQuery(goCtx).Where(&model.User{ID: userID}).Find()
+	user, err := c.RepositoryContainer.UserRepository.NewQuery(goCtx).Where(&model.User{ID: userID}).Find()
 	if err != nil {
 		return err
 	}
@@ -149,7 +147,7 @@ func (c *UserController) GetOneUsersFavorites(ctx context.Context) error {
 	}
 	log.Debug("success to validate request", zap.String("userID", userID))
 
-	favorites, err := c.FavoriteRepository.NewQuery(goCtx).
+	favorites, err := c.RepositoryContainer.FavoriteRepository.NewQuery(goCtx).
 		Where(&model.Favorite{UserID: userID}).
 		JoinClip().
 		FindAll()

--- a/internal/app/middleware/authn_middleware.go
+++ b/internal/app/middleware/authn_middleware.go
@@ -7,6 +7,7 @@ import (
 
 	app_context "github.com/holocycle/holo-back/internal/app/context"
 	"github.com/holocycle/holo-back/pkg/context"
+	app_context2 "github.com/holocycle/holo-back/pkg/context2"
 	"github.com/holocycle/holo-back/pkg/model"
 	"github.com/holocycle/holo-back/pkg/repository"
 
@@ -41,8 +42,7 @@ func (m *AuthnMiddleware) Process(next echo.HandlerFunc) echo.HandlerFunc {
 			return err
 		}
 
-		tx := ctx.GetDB()
-		session, err := repository.NewSessionRepository().NewQuery(tx).
+		session, err := repository.NewSessionRepository().NewQuery(app_context2.FromEchoContext(ctx)).
 			Where(&model.Session{ID: token}).Find()
 		if err != nil {
 			if repository.NotFoundError(err) {

--- a/pkg/repository/bookmark_repository.go
+++ b/pkg/repository/bookmark_repository.go
@@ -1,12 +1,15 @@
 package repository
 
 import (
+	"context"
+
+	app_context "github.com/holocycle/holo-back/pkg/context2"
 	"github.com/holocycle/holo-back/pkg/model"
 	"github.com/jinzhu/gorm"
 )
 
 type BookmarkRepository interface {
-	NewQuery(tx *gorm.DB) BookmarkQuery
+	NewQuery(ctx context.Context) BookmarkQuery
 }
 
 type BookmarkQuery interface {
@@ -25,8 +28,8 @@ func NewBookmarkRepository() BookmarkRepository {
 
 type BookmarkRepositoryImpl struct{}
 
-func (r *BookmarkRepositoryImpl) NewQuery(tx *gorm.DB) BookmarkQuery {
-	return &BookmarkQueryImpl{Tx: tx}
+func (r *BookmarkRepositoryImpl) NewQuery(ctx context.Context) BookmarkQuery {
+	return &BookmarkQueryImpl{Tx: app_context.GetDB(ctx)}
 }
 
 type BookmarkQueryImpl struct {

--- a/pkg/repository/channel_repository.go
+++ b/pkg/repository/channel_repository.go
@@ -1,12 +1,15 @@
 package repository
 
 import (
+	"context"
+
+	app_context "github.com/holocycle/holo-back/pkg/context2"
 	"github.com/holocycle/holo-back/pkg/model"
 	"github.com/jinzhu/gorm"
 )
 
 type ChannelRepository interface {
-	NewQuery(tx *gorm.DB) ChannelQuery
+	NewQuery(ctx context.Context) ChannelQuery
 }
 
 type ChannelQuery interface {
@@ -25,8 +28,8 @@ func NewChannelRepository() ChannelRepository {
 
 type ChannelRepositoryImpl struct{}
 
-func (r *ChannelRepositoryImpl) NewQuery(tx *gorm.DB) ChannelQuery {
-	return &ChannelQueryImpl{Tx: tx}
+func (r *ChannelRepositoryImpl) NewQuery(ctx context.Context) ChannelQuery {
+	return &ChannelQueryImpl{Tx: app_context.GetDB(ctx)}
 }
 
 type ChannelQueryImpl struct {

--- a/pkg/repository/clip_repository.go
+++ b/pkg/repository/clip_repository.go
@@ -1,14 +1,16 @@
 package repository
 
 import (
+	"context"
 	"strings"
 
+	app_context "github.com/holocycle/holo-back/pkg/context2"
 	"github.com/holocycle/holo-back/pkg/model"
 	"github.com/jinzhu/gorm"
 )
 
 type ClipRepository interface {
-	NewQuery(tx *gorm.DB) ClipQuery
+	NewQuery(ctx context.Context) ClipQuery
 }
 
 type ClipQuery interface {
@@ -33,8 +35,8 @@ func NewClipRepository() ClipRepository {
 
 type ClipRepositoryImpl struct{}
 
-func (r *ClipRepositoryImpl) NewQuery(tx *gorm.DB) ClipQuery {
-	return &ClipQueryImpl{Tx: tx}
+func (r *ClipRepositoryImpl) NewQuery(ctx context.Context) ClipQuery {
+	return &ClipQueryImpl{Tx: app_context.GetDB(ctx)}
 }
 
 type ClipQueryImpl struct {

--- a/pkg/repository/clip_tagged_repository.go
+++ b/pkg/repository/clip_tagged_repository.go
@@ -1,12 +1,15 @@
 package repository
 
 import (
+	"context"
+
+	app_context "github.com/holocycle/holo-back/pkg/context2"
 	"github.com/holocycle/holo-back/pkg/model"
 	"github.com/jinzhu/gorm"
 )
 
 type ClipTaggedRepository interface {
-	NewQuery(tx *gorm.DB) ClipTaggedQuery
+	NewQuery(ctx context.Context) ClipTaggedQuery
 }
 
 type ClipTaggedQuery interface {
@@ -26,8 +29,8 @@ func NewClipTaggedRepository() ClipTaggedRepository {
 
 type ClipTaggedRepositoryImpl struct{}
 
-func (r *ClipTaggedRepositoryImpl) NewQuery(tx *gorm.DB) ClipTaggedQuery {
-	return &ClipTaggedQueryImpl{Tx: tx}
+func (r *ClipTaggedRepositoryImpl) NewQuery(ctx context.Context) ClipTaggedQuery {
+	return &ClipTaggedQueryImpl{Tx: app_context.GetDB(ctx)}
 }
 
 type ClipTaggedQueryImpl struct {

--- a/pkg/repository/cliplist_contain_repository.go
+++ b/pkg/repository/cliplist_contain_repository.go
@@ -1,15 +1,18 @@
 package repository
 
 import (
+	"context"
+
+	app_context "github.com/holocycle/holo-back/pkg/context2"
 	"github.com/holocycle/holo-back/pkg/model"
 	"github.com/jinzhu/gorm"
 )
 
 type CliplistContainRepository interface {
-	NewQuery(tx *gorm.DB) CliplistContainQuery
+	NewQuery(ctx context.Context) CliplistContainQuery
 
-	InsertToList(tx *gorm.DB, cliplistContain *model.CliplistContain) error
-	DeleteFromList(tx *gorm.DB, cliplistContain *model.CliplistContain) error
+	InsertToList(ctx context.Context, cliplistContain *model.CliplistContain) error
+	DeleteFromList(ctx context.Context, cliplistContain *model.CliplistContain) error
 }
 
 type CliplistContainQuery interface {
@@ -29,8 +32,8 @@ func NewCliplistContainRepository() CliplistContainRepository {
 
 type CliplistContainRepositoryImpl struct{}
 
-func (r *CliplistContainRepositoryImpl) NewQuery(tx *gorm.DB) CliplistContainQuery {
-	return &CliplistContainQueryImpl{Tx: tx}
+func (r *CliplistContainRepositoryImpl) NewQuery(ctx context.Context) CliplistContainQuery {
+	return &CliplistContainQueryImpl{Tx: app_context.GetDB(ctx)}
 }
 
 type CliplistContainQueryImpl struct {
@@ -81,7 +84,8 @@ func (q *CliplistContainQueryImpl) Delete() (int, error) {
 	return (int)(res.RowsAffected), newErr(res.Error)
 }
 
-func (r *CliplistContainRepositoryImpl) InsertToList(tx *gorm.DB, cliplistContain *model.CliplistContain) error {
+func (r *CliplistContainRepositoryImpl) InsertToList(ctx context.Context, cliplistContain *model.CliplistContain) error {
+	tx := app_context.GetDB(ctx)
 	err := tx.Model(&model.CliplistContain{}).
 		Where(&model.CliplistContain{CliplistID: cliplistContain.CliplistID}).
 		Where("index >= ?", cliplistContain.Index).
@@ -98,7 +102,8 @@ func (r *CliplistContainRepositoryImpl) InsertToList(tx *gorm.DB, cliplistContai
 	return nil
 }
 
-func (r *CliplistContainRepositoryImpl) DeleteFromList(tx *gorm.DB, cliplistContain *model.CliplistContain) error {
+func (r *CliplistContainRepositoryImpl) DeleteFromList(ctx context.Context, cliplistContain *model.CliplistContain) error {
+	tx := app_context.GetDB(ctx)
 	err := tx.Delete(cliplistContain).Error
 	if err != nil {
 		return newErr(err)

--- a/pkg/repository/cliplist_repository.go
+++ b/pkg/repository/cliplist_repository.go
@@ -1,12 +1,15 @@
 package repository
 
 import (
+	"context"
+
+	app_context "github.com/holocycle/holo-back/pkg/context2"
 	"github.com/holocycle/holo-back/pkg/model"
 	"github.com/jinzhu/gorm"
 )
 
 type CliplistRepository interface {
-	NewQuery(tx *gorm.DB) CliplistQuery
+	NewQuery(ctx context.Context) CliplistQuery
 }
 
 type CliplistQuery interface {
@@ -26,8 +29,8 @@ func NewCliplistRepository() CliplistRepository {
 
 type CliplistRepositoryImpl struct{}
 
-func (r *CliplistRepositoryImpl) NewQuery(tx *gorm.DB) CliplistQuery {
-	return &CliplistQueryImpl{Tx: tx}
+func (r *CliplistRepositoryImpl) NewQuery(ctx context.Context) CliplistQuery {
+	return &CliplistQueryImpl{Tx: app_context.GetDB(ctx)}
 }
 
 type CliplistQueryImpl struct {

--- a/pkg/repository/comment_repository.go
+++ b/pkg/repository/comment_repository.go
@@ -1,12 +1,15 @@
 package repository
 
 import (
+	"context"
+
+	app_context "github.com/holocycle/holo-back/pkg/context2"
 	"github.com/holocycle/holo-back/pkg/model"
 	"github.com/jinzhu/gorm"
 )
 
 type CommentRepository interface {
-	NewQuery(tx *gorm.DB) CommentQuery
+	NewQuery(ctx context.Context) CommentQuery
 }
 
 type CommentQuery interface {
@@ -30,8 +33,8 @@ func NewCommentRepository() CommentRepository {
 
 type CommentRepositoryImpl struct{}
 
-func (r *CommentRepositoryImpl) NewQuery(tx *gorm.DB) CommentQuery {
-	return &CommentQueryImpl{Tx: tx}
+func (r *CommentRepositoryImpl) NewQuery(ctx context.Context) CommentQuery {
+	return &CommentQueryImpl{Tx: app_context.GetDB(ctx)}
 }
 
 type CommentQueryImpl struct {

--- a/pkg/repository/container.go
+++ b/pkg/repository/container.go
@@ -1,0 +1,35 @@
+package repository
+
+type Container struct {
+	LiverRepository           LiverRepository
+	ChannelRepository         ChannelRepository
+	VideoRepository           VideoRepository
+	UserRepository            UserRepository
+	SessionRepository         SessionRepository
+	ClipRepository            ClipRepository
+	FavoriteRepository        FavoriteRepository
+	CommentRepository         CommentRepository
+	TagRepository             TagRepository
+	ClipTaggedRepository      ClipTaggedRepository
+	CliplistRepository        CliplistRepository
+	CliplistContainRepository CliplistContainRepository
+	BookmarkRepository        BookmarkRepository
+}
+
+func NewContainer() *Container {
+	return &Container{
+		LiverRepository:           NewLiverRepository(),
+		ChannelRepository:         NewChannelRepository(),
+		VideoRepository:           NewVideoRepository(),
+		UserRepository:            NewUserRepository(),
+		SessionRepository:         NewSessionRepository(),
+		ClipRepository:            NewClipRepository(),
+		FavoriteRepository:        NewFavoriteRepository(),
+		CommentRepository:         NewCommentRepository(),
+		TagRepository:             NewTagRepository(),
+		ClipTaggedRepository:      NewClipTaggedRepository(),
+		CliplistRepository:        NewCliplistRepository(),
+		CliplistContainRepository: NewCliplistContainRepository(),
+		BookmarkRepository:        NewBookmarkRepository(),
+	}
+}

--- a/pkg/repository/favorite_repository.go
+++ b/pkg/repository/favorite_repository.go
@@ -1,12 +1,15 @@
 package repository
 
 import (
+	"context"
+
+	app_context "github.com/holocycle/holo-back/pkg/context2"
 	"github.com/holocycle/holo-back/pkg/model"
 	"github.com/jinzhu/gorm"
 )
 
 type FavoriteRepository interface {
-	NewQuery(tx *gorm.DB) FavoriteQuery
+	NewQuery(ctx context.Context) FavoriteQuery
 }
 
 type FavoriteQuery interface {
@@ -26,8 +29,8 @@ func NewFavoriteRepository() FavoriteRepository {
 
 type FavoriteRepositoryImpl struct{}
 
-func (r *FavoriteRepositoryImpl) NewQuery(tx *gorm.DB) FavoriteQuery {
-	return &FavoriteQueryImpl{Tx: tx}
+func (r *FavoriteRepositoryImpl) NewQuery(ctx context.Context) FavoriteQuery {
+	return &FavoriteQueryImpl{Tx: app_context.GetDB(ctx)}
 }
 
 type FavoriteQueryImpl struct {

--- a/pkg/repository/liver_repository.go
+++ b/pkg/repository/liver_repository.go
@@ -1,12 +1,15 @@
 package repository
 
 import (
+	"context"
+
+	app_context "github.com/holocycle/holo-back/pkg/context2"
 	"github.com/holocycle/holo-back/pkg/model"
 	"github.com/jinzhu/gorm"
 )
 
 type LiverRepository interface {
-	NewQuery(tx *gorm.DB) LiverQuery
+	NewQuery(ctx context.Context) LiverQuery
 }
 
 type LiverQuery interface {
@@ -26,8 +29,8 @@ func NewLiverRepository() LiverRepository {
 
 type LiverRepositoryImpl struct{}
 
-func (r *LiverRepositoryImpl) NewQuery(tx *gorm.DB) LiverQuery {
-	return &LiverQueryImpl{Tx: tx}
+func (r *LiverRepositoryImpl) NewQuery(ctx context.Context) LiverQuery {
+	return &LiverQueryImpl{Tx: app_context.GetDB(ctx)}
 }
 
 type LiverQueryImpl struct {

--- a/pkg/repository/session_repository.go
+++ b/pkg/repository/session_repository.go
@@ -1,12 +1,15 @@
 package repository
 
 import (
+	"context"
+
+	app_context "github.com/holocycle/holo-back/pkg/context2"
 	"github.com/holocycle/holo-back/pkg/model"
 	"github.com/jinzhu/gorm"
 )
 
 type SessionRepository interface {
-	NewQuery(tx *gorm.DB) SessionQuery
+	NewQuery(ctx context.Context) SessionQuery
 }
 
 type SessionQuery interface {
@@ -25,8 +28,8 @@ func NewSessionRepository() SessionRepository {
 
 type SessionRepositoryImpl struct{}
 
-func (r *SessionRepositoryImpl) NewQuery(tx *gorm.DB) SessionQuery {
-	return &SessionQueryImpl{Tx: tx}
+func (r *SessionRepositoryImpl) NewQuery(ctx context.Context) SessionQuery {
+	return &SessionQueryImpl{Tx: app_context.GetDB(ctx)}
 }
 
 type SessionQueryImpl struct {

--- a/pkg/repository/tag_repository.go
+++ b/pkg/repository/tag_repository.go
@@ -1,13 +1,16 @@
 package repository
 
 import (
+	"context"
+
 	"github.com/jinzhu/gorm"
 
+	app_context "github.com/holocycle/holo-back/pkg/context2"
 	"github.com/holocycle/holo-back/pkg/model"
 )
 
 type TagRepository interface {
-	NewQuery(tx *gorm.DB) TagQuery
+	NewQuery(ctx context.Context) TagQuery
 }
 
 type TagQuery interface {
@@ -27,8 +30,8 @@ func NewTagRepository() TagRepository {
 type TagRepositoryImpl struct {
 }
 
-func (r *TagRepositoryImpl) NewQuery(tx *gorm.DB) TagQuery {
-	return &TagQueryImpl{Tx: tx}
+func (r *TagRepositoryImpl) NewQuery(ctx context.Context) TagQuery {
+	return &TagQueryImpl{Tx: app_context.GetDB(ctx)}
 }
 
 type TagQueryImpl struct {

--- a/pkg/repository/user_repository.go
+++ b/pkg/repository/user_repository.go
@@ -1,12 +1,15 @@
 package repository
 
 import (
+	"context"
+
+	app_context "github.com/holocycle/holo-back/pkg/context2"
 	"github.com/holocycle/holo-back/pkg/model"
 	"github.com/jinzhu/gorm"
 )
 
 type UserRepository interface {
-	NewQuery(tx *gorm.DB) UserQuery
+	NewQuery(ctx context.Context) UserQuery
 }
 
 type UserQuery interface {
@@ -28,8 +31,8 @@ func NewUserRepository() UserRepository {
 
 type UserRepositoryImpl struct{}
 
-func (r *UserRepositoryImpl) NewQuery(tx *gorm.DB) UserQuery {
-	return &UserQueryImpl{Tx: tx}
+func (r *UserRepositoryImpl) NewQuery(ctx context.Context) UserQuery {
+	return &UserQueryImpl{Tx: app_context.GetDB(ctx)}
 }
 
 type UserQueryImpl struct {

--- a/pkg/repository/video_repository.go
+++ b/pkg/repository/video_repository.go
@@ -1,12 +1,15 @@
 package repository
 
 import (
+	"context"
+
+	app_context "github.com/holocycle/holo-back/pkg/context2"
 	"github.com/holocycle/holo-back/pkg/model"
 	"github.com/jinzhu/gorm"
 )
 
 type VideoRepository interface {
-	NewQuery(tx *gorm.DB) VideoQuery
+	NewQuery(ctx context.Context) VideoQuery
 }
 
 type VideoQuery interface {
@@ -25,8 +28,8 @@ func NewVideoRepository() VideoRepository {
 
 type VideoRepositoryImpl struct{}
 
-func (r *VideoRepositoryImpl) NewQuery(tx *gorm.DB) VideoQuery {
-	return &VideoQueryImpl{Tx: tx}
+func (r *VideoRepositoryImpl) NewQuery(ctx context.Context) VideoQuery {
+	return &VideoQueryImpl{Tx: app_context.GetDB(ctx)}
 }
 
 type VideoQueryImpl struct {

--- a/pkg/service/cliplist_item_service.go
+++ b/pkg/service/cliplist_item_service.go
@@ -54,7 +54,7 @@ func (s *CliplistItemServiceImpl) GetCliplistItem(
 	index int,
 	req *api.GetCliplistItemRequest,
 ) (*api.GetCliplistItemResponse, service.Error) {
-	_, err := s.CliplistRepository.NewQuery(app_context.GetDB(ctx)).
+	_, err := s.CliplistRepository.NewQuery(ctx).
 		Where(&model.Cliplist{
 			ID:     cliplistID,
 			Status: model.CliplistStatusPublic,
@@ -67,7 +67,7 @@ func (s *CliplistItemServiceImpl) GetCliplistItem(
 		return nil, InternalError.With(err)
 	}
 
-	cliplistContain, err := s.CliplistContainRepository.NewQuery(app_context.GetDB(ctx)).
+	cliplistContain, err := s.CliplistContainRepository.NewQuery(ctx).
 		JoinClip().
 		Where(&model.CliplistContain{
 			CliplistID: cliplistID,
@@ -91,7 +91,7 @@ func (s *CliplistItemServiceImpl) PostCliplistItem(
 	index int,
 	req *api.PostCliplistItemRequest,
 ) (*api.PostCliplistItemResponse, service.Error) {
-	cliplist, err := s.CliplistRepository.NewQuery(app_context.GetDB(ctx)).
+	cliplist, err := s.CliplistRepository.NewQuery(ctx).
 		Where(&model.Cliplist{
 			ID:     cliplistID,
 			Status: model.CliplistStatusPublic,
@@ -107,7 +107,7 @@ func (s *CliplistItemServiceImpl) PostCliplistItem(
 		return nil, NoPermissionToCliplist
 	}
 
-	cliplistContains, err := s.CliplistContainRepository.NewQuery(app_context.GetDB(ctx)).
+	cliplistContains, err := s.CliplistContainRepository.NewQuery(ctx).
 		Where(&model.CliplistContain{
 			CliplistID: cliplistID,
 		}).FindAll()
@@ -118,7 +118,7 @@ func (s *CliplistItemServiceImpl) PostCliplistItem(
 		return nil, CliplistIndexOutOfRange
 	}
 
-	_, err = s.ClipRepository.NewQuery(app_context.GetDB(ctx)).Where(&model.Clip{
+	_, err = s.ClipRepository.NewQuery(ctx).Where(&model.Clip{
 		ID:     req.ClipID,
 		Status: model.ClipStatusPublic,
 	}).Find()
@@ -134,7 +134,7 @@ func (s *CliplistItemServiceImpl) PostCliplistItem(
 		index,
 		req.ClipID,
 	)
-	err = s.CliplistContainRepository.InsertToList(app_context.GetDB(ctx), cliplistContain)
+	err = s.CliplistContainRepository.InsertToList(ctx, cliplistContain)
 	if err != nil {
 		return nil, InternalError.With(err)
 	}
@@ -150,7 +150,7 @@ func (s *CliplistItemServiceImpl) DeleteCliplistItem(
 	index int,
 	req *api.DeleteCliplistItemRequest,
 ) (*api.DeleteCliplistItemResponse, service.Error) {
-	cliplist, err := s.CliplistRepository.NewQuery(app_context.GetDB(ctx)).
+	cliplist, err := s.CliplistRepository.NewQuery(ctx).
 		Where(&model.Cliplist{
 			ID:     cliplistID,
 			Status: model.CliplistStatusPublic,
@@ -166,7 +166,7 @@ func (s *CliplistItemServiceImpl) DeleteCliplistItem(
 		return nil, NoPermissionToCliplist.With(err)
 	}
 
-	cliplistContains, err := s.CliplistContainRepository.NewQuery(app_context.GetDB(ctx)).
+	cliplistContains, err := s.CliplistContainRepository.NewQuery(ctx).
 		Where(&model.CliplistContain{
 			CliplistID: cliplistID,
 		}).FindAll()
@@ -177,7 +177,7 @@ func (s *CliplistItemServiceImpl) DeleteCliplistItem(
 		return nil, CliplistIndexOutOfRange
 	}
 
-	err = s.CliplistContainRepository.DeleteFromList(app_context.GetDB(ctx), cliplistContains[index])
+	err = s.CliplistContainRepository.DeleteFromList(ctx, cliplistContains[index])
 	if err != nil {
 		return nil, InternalError.With(err)
 	}

--- a/pkg/service/cliplist_item_service.go
+++ b/pkg/service/cliplist_item_service.go
@@ -35,16 +35,12 @@ type CliplistItemService interface {
 }
 
 type CliplistItemServiceImpl struct {
-	ClipRepository            repository.ClipRepository
-	CliplistRepository        repository.CliplistRepository
-	CliplistContainRepository repository.CliplistContainRepository
+	RepositoryContainer *repository.Container
 }
 
 func NewCliplistItemService() CliplistItemService {
 	return &CliplistItemServiceImpl{
-		ClipRepository:            repository.NewClipRepository(),
-		CliplistRepository:        repository.NewCliplistRepository(),
-		CliplistContainRepository: repository.NewCliplistContainRepository(),
+		RepositoryContainer: repository.NewContainer(),
 	}
 }
 
@@ -54,7 +50,7 @@ func (s *CliplistItemServiceImpl) GetCliplistItem(
 	index int,
 	req *api.GetCliplistItemRequest,
 ) (*api.GetCliplistItemResponse, service.Error) {
-	_, err := s.CliplistRepository.NewQuery(ctx).
+	_, err := s.RepositoryContainer.CliplistRepository.NewQuery(ctx).
 		Where(&model.Cliplist{
 			ID:     cliplistID,
 			Status: model.CliplistStatusPublic,
@@ -67,7 +63,7 @@ func (s *CliplistItemServiceImpl) GetCliplistItem(
 		return nil, InternalError.With(err)
 	}
 
-	cliplistContain, err := s.CliplistContainRepository.NewQuery(ctx).
+	cliplistContain, err := s.RepositoryContainer.CliplistContainRepository.NewQuery(ctx).
 		JoinClip().
 		Where(&model.CliplistContain{
 			CliplistID: cliplistID,
@@ -91,7 +87,7 @@ func (s *CliplistItemServiceImpl) PostCliplistItem(
 	index int,
 	req *api.PostCliplistItemRequest,
 ) (*api.PostCliplistItemResponse, service.Error) {
-	cliplist, err := s.CliplistRepository.NewQuery(ctx).
+	cliplist, err := s.RepositoryContainer.CliplistRepository.NewQuery(ctx).
 		Where(&model.Cliplist{
 			ID:     cliplistID,
 			Status: model.CliplistStatusPublic,
@@ -107,7 +103,7 @@ func (s *CliplistItemServiceImpl) PostCliplistItem(
 		return nil, NoPermissionToCliplist
 	}
 
-	cliplistContains, err := s.CliplistContainRepository.NewQuery(ctx).
+	cliplistContains, err := s.RepositoryContainer.CliplistContainRepository.NewQuery(ctx).
 		Where(&model.CliplistContain{
 			CliplistID: cliplistID,
 		}).FindAll()
@@ -118,7 +114,7 @@ func (s *CliplistItemServiceImpl) PostCliplistItem(
 		return nil, CliplistIndexOutOfRange
 	}
 
-	_, err = s.ClipRepository.NewQuery(ctx).Where(&model.Clip{
+	_, err = s.RepositoryContainer.ClipRepository.NewQuery(ctx).Where(&model.Clip{
 		ID:     req.ClipID,
 		Status: model.ClipStatusPublic,
 	}).Find()
@@ -134,7 +130,7 @@ func (s *CliplistItemServiceImpl) PostCliplistItem(
 		index,
 		req.ClipID,
 	)
-	err = s.CliplistContainRepository.InsertToList(ctx, cliplistContain)
+	err = s.RepositoryContainer.CliplistContainRepository.InsertToList(ctx, cliplistContain)
 	if err != nil {
 		return nil, InternalError.With(err)
 	}
@@ -150,7 +146,7 @@ func (s *CliplistItemServiceImpl) DeleteCliplistItem(
 	index int,
 	req *api.DeleteCliplistItemRequest,
 ) (*api.DeleteCliplistItemResponse, service.Error) {
-	cliplist, err := s.CliplistRepository.NewQuery(ctx).
+	cliplist, err := s.RepositoryContainer.CliplistRepository.NewQuery(ctx).
 		Where(&model.Cliplist{
 			ID:     cliplistID,
 			Status: model.CliplistStatusPublic,
@@ -166,7 +162,7 @@ func (s *CliplistItemServiceImpl) DeleteCliplistItem(
 		return nil, NoPermissionToCliplist.With(err)
 	}
 
-	cliplistContains, err := s.CliplistContainRepository.NewQuery(ctx).
+	cliplistContains, err := s.RepositoryContainer.CliplistContainRepository.NewQuery(ctx).
 		Where(&model.CliplistContain{
 			CliplistID: cliplistID,
 		}).FindAll()
@@ -177,7 +173,7 @@ func (s *CliplistItemServiceImpl) DeleteCliplistItem(
 		return nil, CliplistIndexOutOfRange
 	}
 
-	err = s.CliplistContainRepository.DeleteFromList(ctx, cliplistContains[index])
+	err = s.RepositoryContainer.CliplistContainRepository.DeleteFromList(ctx, cliplistContains[index])
 	if err != nil {
 		return nil, InternalError.With(err)
 	}

--- a/pkg/service/cliplist_service.go
+++ b/pkg/service/cliplist_service.go
@@ -42,14 +42,12 @@ type CliplistService interface {
 }
 
 type CliplistServiceImpl struct {
-	ClipRepository     repository.ClipRepository
-	CliplistRepository repository.CliplistRepository
+	RepositoryContainer *repository.Container
 }
 
 func NewCliplistService() CliplistService {
 	return &CliplistServiceImpl{
-		ClipRepository:     repository.NewClipRepository(),
-		CliplistRepository: repository.NewCliplistRepository(),
+		RepositoryContainer: repository.NewContainer(),
 	}
 }
 
@@ -66,7 +64,7 @@ func (s *CliplistServiceImpl) ListCliplists(
 
 	// TODO: OrderBy
 
-	cliplist, err := s.CliplistRepository.NewQuery(ctx).
+	cliplist, err := s.RepositoryContainer.CliplistRepository.NewQuery(ctx).
 		JoinClip().
 		Where(&model.Cliplist{Status: model.CliplistStatusPublic}).
 		FindAll()
@@ -84,7 +82,7 @@ func (s *CliplistServiceImpl) GetCliplist(
 	cliplistID string,
 	req *api.GetCliplistRequest,
 ) (*api.GetCliplistResponse, service.Error) {
-	cliplist, err := s.CliplistRepository.NewQuery(ctx).
+	cliplist, err := s.RepositoryContainer.CliplistRepository.NewQuery(ctx).
 		JoinClip().
 		Where(&model.Cliplist{
 			ID:     cliplistID,
@@ -121,7 +119,7 @@ func (s *CliplistServiceImpl) PostCliplist(
 		req.Description,
 		model.CliplistStatusPublic,
 	)
-	err := s.CliplistRepository.NewQuery(ctx).Create(cliplist)
+	err := s.RepositoryContainer.CliplistRepository.NewQuery(ctx).Create(cliplist)
 	if err != nil {
 		return nil, InternalError.With(err)
 	}
@@ -136,7 +134,7 @@ func (s *CliplistServiceImpl) PutCliplist(
 	cliplistID string,
 	req *api.PutCliplistRequest,
 ) (*api.PutCliplistResponse, service.Error) {
-	cliplist, err := s.CliplistRepository.NewQuery(ctx).
+	cliplist, err := s.RepositoryContainer.CliplistRepository.NewQuery(ctx).
 		Where(&model.Cliplist{
 			ID:     cliplistID,
 			Status: model.CliplistStatusPublic,
@@ -154,7 +152,7 @@ func (s *CliplistServiceImpl) PutCliplist(
 
 	cliplist.Title = req.Title
 	cliplist.Description = req.Description
-	if err = s.CliplistRepository.NewQuery(ctx).Save(cliplist); err != nil {
+	if err = s.RepositoryContainer.CliplistRepository.NewQuery(ctx).Save(cliplist); err != nil {
 		return nil, InternalError.With(err)
 	}
 
@@ -168,7 +166,7 @@ func (s *CliplistServiceImpl) DeleteCliplist(
 	cliplistID string,
 	req *api.DeleteCliplistRequest,
 ) (*api.DeleteCliplistResponse, service.Error) {
-	cliplist, err := s.CliplistRepository.NewQuery(ctx).
+	cliplist, err := s.RepositoryContainer.CliplistRepository.NewQuery(ctx).
 		Where(&model.Cliplist{
 			ID:     cliplistID,
 			Status: model.CliplistStatusPublic,
@@ -185,7 +183,7 @@ func (s *CliplistServiceImpl) DeleteCliplist(
 	}
 
 	cliplist.Status = model.CliplistStatusDeleted
-	if err := s.CliplistRepository.NewQuery(ctx).Save(cliplist); err != nil {
+	if err := s.RepositoryContainer.CliplistRepository.NewQuery(ctx).Save(cliplist); err != nil {
 		return nil, InternalError.With(err)
 	}
 

--- a/pkg/service/cliplist_service.go
+++ b/pkg/service/cliplist_service.go
@@ -66,7 +66,7 @@ func (s *CliplistServiceImpl) ListCliplists(
 
 	// TODO: OrderBy
 
-	cliplist, err := s.CliplistRepository.NewQuery(tx).
+	cliplist, err := s.CliplistRepository.NewQuery(ctx).
 		JoinClip().
 		Where(&model.Cliplist{Status: model.CliplistStatusPublic}).
 		FindAll()
@@ -84,7 +84,7 @@ func (s *CliplistServiceImpl) GetCliplist(
 	cliplistID string,
 	req *api.GetCliplistRequest,
 ) (*api.GetCliplistResponse, service.Error) {
-	cliplist, err := s.CliplistRepository.NewQuery(app_context.GetDB(ctx)).
+	cliplist, err := s.CliplistRepository.NewQuery(ctx).
 		JoinClip().
 		Where(&model.Cliplist{
 			ID:     cliplistID,
@@ -121,7 +121,7 @@ func (s *CliplistServiceImpl) PostCliplist(
 		req.Description,
 		model.CliplistStatusPublic,
 	)
-	err := s.CliplistRepository.NewQuery(app_context.GetDB(ctx)).Create(cliplist)
+	err := s.CliplistRepository.NewQuery(ctx).Create(cliplist)
 	if err != nil {
 		return nil, InternalError.With(err)
 	}
@@ -136,7 +136,7 @@ func (s *CliplistServiceImpl) PutCliplist(
 	cliplistID string,
 	req *api.PutCliplistRequest,
 ) (*api.PutCliplistResponse, service.Error) {
-	cliplist, err := s.CliplistRepository.NewQuery(app_context.GetDB(ctx)).
+	cliplist, err := s.CliplistRepository.NewQuery(ctx).
 		Where(&model.Cliplist{
 			ID:     cliplistID,
 			Status: model.CliplistStatusPublic,
@@ -154,7 +154,7 @@ func (s *CliplistServiceImpl) PutCliplist(
 
 	cliplist.Title = req.Title
 	cliplist.Description = req.Description
-	if err = s.CliplistRepository.NewQuery(app_context.GetDB(ctx)).Save(cliplist); err != nil {
+	if err = s.CliplistRepository.NewQuery(ctx).Save(cliplist); err != nil {
 		return nil, InternalError.With(err)
 	}
 
@@ -168,7 +168,7 @@ func (s *CliplistServiceImpl) DeleteCliplist(
 	cliplistID string,
 	req *api.DeleteCliplistRequest,
 ) (*api.DeleteCliplistResponse, service.Error) {
-	cliplist, err := s.CliplistRepository.NewQuery(app_context.GetDB(ctx)).
+	cliplist, err := s.CliplistRepository.NewQuery(ctx).
 		Where(&model.Cliplist{
 			ID:     cliplistID,
 			Status: model.CliplistStatusPublic,
@@ -185,7 +185,7 @@ func (s *CliplistServiceImpl) DeleteCliplist(
 	}
 
 	cliplist.Status = model.CliplistStatusDeleted
-	if err := s.CliplistRepository.NewQuery(app_context.GetDB(ctx)).Save(cliplist); err != nil {
+	if err := s.CliplistRepository.NewQuery(ctx).Save(cliplist); err != nil {
 		return nil, InternalError.With(err)
 	}
 


### PR DESCRIPTION
- repository.NewQueryの引数をgolangのcontextに変更
  - ctxに含まれたloggerが渡せる -> repositoryでもロギングできる
  - 他のctxの機能も使えるメリットがある (Cancelなど)
- repository.Containerを作成した
  - service, controllerは直接RepositoryをnewせずにNewContainerする
  - いちいち依存するRepositoryを個別にNewしなくてよくなった