### PR TITLE
ログイン時にiconのURLやユーザ名を取得してくるように修正

### DIFF
--- a/config/app/config.yaml
+++ b/config/app/config.yaml
@@ -12,6 +12,7 @@ googleoauth2:
   googleauthurl: "https://accounts.google.com/o/oauth2/auth"
   googletokenurl: "https://accounts.google.com/o/oauth2/token"
   googletokeninfourl: "https://oauth2.googleapis.com/tokeninfo"
+  googleuserinfourl: "https://www.googleapis.com/oauth2/v1/userinfo"
   clientid: "904632099489-0cfq1s2icvrncfeu2ufk4lkivp50i60q.apps.googleusercontent.com"
   clientsecret: "" # env
   clientredirecturl: "" # overlay

--- a/internal/app/config/google_auth_config.go
+++ b/internal/app/config/google_auth_config.go
@@ -4,6 +4,7 @@ type GoogleOAuth2Config struct {
 	GoogleAuthURL      string `required:"true"`
 	GoogleTokenURL     string `required:"true"`
 	GoogleTokenInfoURL string `required:"true"`
+	GoogleUserInfoURL  string `required:"true"`
 	ClientID           string `required:"true"`
 	ClientSecret       string `required:"true" env:"GOOGLE_OAUTH2_CLIENT_SECRET"`
 	ClientRedirectURL  string `required:"true"`


### PR DESCRIPTION
## 対応内容

ログイン時にユーザ情報を取得するAPI `https://www.googleapis.com/oauth2/v1/userinfo?access_token=XXXXX`  を叩くようにした。
APIを叩いた後、icon画像のURLとユーザ名をuserテーブルへ格納するようにした。
2回目以降のログインユーザ向けに、userテーブル情報とユーザ情報取得時の情報に食い違いがあった場合に情報を更新するようにした。